### PR TITLE
Compact GUI spacing

### DIFF
--- a/meeting_summarizer/lib/core/widgets/theme_settings_widget.dart
+++ b/meeting_summarizer/lib/core/widgets/theme_settings_widget.dart
@@ -197,7 +197,7 @@ class _ThemeSettingsWidgetState extends State<ThemeSettingsWidget> {
         ),
         const SizedBox(height: 12),
         Container(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainerHighest.withValues(
               alpha: 0.5,

--- a/meeting_summarizer/lib/features/audio_recording/presentation/screens/recording_screen.dart
+++ b/meeting_summarizer/lib/features/audio_recording/presentation/screens/recording_screen.dart
@@ -450,23 +450,23 @@ class _RecordingScreenState extends State<RecordingScreen>
     if (screenWidth > 1200) {
       // Large desktop screens
       padding = const EdgeInsets.symmetric(horizontal: 80.0, vertical: 40.0);
-      verticalSpacing = 50.0;
-      majorSpacing = 80.0;
+      verticalSpacing = 40.0;
+      majorSpacing = 60.0;
     } else if (screenWidth > 800) {
       // Medium desktop/tablet screens
       padding = const EdgeInsets.symmetric(horizontal: 60.0, vertical: 32.0);
-      verticalSpacing = 40.0;
-      majorSpacing = 70.0;
+      verticalSpacing = 32.0;
+      majorSpacing = 50.0;
     } else if (screenWidth > 600) {
       // Small desktop/large tablet
       padding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
-      verticalSpacing = 35.0;
-      majorSpacing = 60.0;
+      verticalSpacing = 28.0;
+      majorSpacing = 40.0;
     } else {
       // Mobile screens
       padding = const EdgeInsets.all(24.0);
-      verticalSpacing = 30.0;
-      majorSpacing = 50.0;
+      verticalSpacing = 24.0;
+      majorSpacing = 30.0;
     }
 
     // Determine if we should use a wide layout (side-by-side) or narrow layout (stacked)
@@ -844,7 +844,7 @@ class _RecordingScreenState extends State<RecordingScreen>
           ),
         ),
 
-        const SizedBox(height: 16),
+        const SizedBox(height: 12),
 
         // Waveform Visualizer
         AnimatedSwitcher(
@@ -1217,7 +1217,7 @@ class _RecordingScreenState extends State<RecordingScreen>
       iconSize = 22;
     } else if (screenWidth > 600) {
       textScale = 1.0;
-      padding = const EdgeInsets.all(16);
+      padding = const EdgeInsets.all(12);
       borderRadius = 12;
       iconSize = 20;
     } else {

--- a/meeting_summarizer/lib/features/audio_recording/presentation/widgets/waveform_settings.dart
+++ b/meeting_summarizer/lib/features/audio_recording/presentation/widgets/waveform_settings.dart
@@ -186,7 +186,7 @@ class _WaveformSettingsState extends State<WaveformSettings>
                     contentPadding: EdgeInsets.zero,
                   ),
 
-                  const SizedBox(height: 16),
+                  const SizedBox(height: 12),
 
                   // Color Selection
                   Text(
@@ -235,7 +235,7 @@ class _WaveformSettingsState extends State<WaveformSettings>
                     }).toList(),
                   ),
 
-                  const SizedBox(height: 16),
+                  const SizedBox(height: 12),
 
                   // Performance Info
                   Container(

--- a/meeting_summarizer/lib/features/audio_recording/presentation/widgets/waveform_stats.dart
+++ b/meeting_summarizer/lib/features/audio_recording/presentation/widgets/waveform_stats.dart
@@ -96,7 +96,7 @@ class WaveformStats extends StatelessWidget {
               ],
             ),
 
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
 
             // Duration and Format Info
             Row(
@@ -121,7 +121,7 @@ class WaveformStats extends StatelessWidget {
               ],
             ),
 
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
 
             // Amplitude Information
             Column(
@@ -160,7 +160,7 @@ class WaveformStats extends StatelessWidget {
               ],
             ),
 
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
 
             // Data Points and Performance
             Row(

--- a/meeting_summarizer/lib/features/summary/presentation/screens/summary_screen.dart
+++ b/meeting_summarizer/lib/features/summary/presentation/screens/summary_screen.dart
@@ -541,7 +541,7 @@ class _SummaryScreenState extends State<SummaryScreen>
             summary: _currentSummary!,
             onDelete: () => _deleteSummary(_currentSummary!.id),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           if (_currentSummary!.actionItems?.isNotEmpty ?? false)
             ActionItemsList(
               actionItems: _currentSummary!.actionItems!,
@@ -560,7 +560,7 @@ class _SummaryScreenState extends State<SummaryScreen>
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(Icons.summarize, size: 64, color: Colors.grey[400]),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           Text(
             'No Summaries Available',
             style: Theme.of(

--- a/meeting_summarizer/lib/features/summary/presentation/widgets/action_items_list.dart
+++ b/meeting_summarizer/lib/features/summary/presentation/widgets/action_items_list.dart
@@ -37,7 +37,7 @@ class _ActionItemsListState extends State<ActionItemsList> {
     return Card(
       elevation: 2,
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -53,7 +53,7 @@ class _ActionItemsListState extends State<ActionItemsList> {
                 ),
               ],
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
             ListView.separated(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),

--- a/meeting_summarizer/lib/features/summary/presentation/widgets/summary_controls.dart
+++ b/meeting_summarizer/lib/features/summary/presentation/widgets/summary_controls.dart
@@ -95,15 +95,15 @@ class _SummaryControlsState extends State<SummaryControls>
     return Card(
       elevation: 2,
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildHeader(),
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
             if (widget.isGenerating) _buildGenerationProgress(),
             _buildTypeSelector(),
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
             _buildActionButtons(),
           ],
         ),
@@ -149,7 +149,7 @@ class _SummaryControlsState extends State<SummaryControls>
             context,
           ).textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: 12),
       ],
     );
   }

--- a/meeting_summarizer/lib/features/summary/presentation/widgets/summary_generator.dart
+++ b/meeting_summarizer/lib/features/summary/presentation/widgets/summary_generator.dart
@@ -286,17 +286,17 @@ class _SummaryGeneratorState extends State<SummaryGenerator>
         child: Card(
           elevation: 4,
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _buildHeader(),
-                const SizedBox(height: 16),
+                const SizedBox(height: 12),
                 _buildProgressIndicator(),
-                const SizedBox(height: 16),
+                const SizedBox(height: 12),
                 _buildStatusMessage(),
                 if (widget.isGenerating) ...[
-                  const SizedBox(height: 16),
+                  const SizedBox(height: 12),
                   _buildGenerationSteps(),
                 ],
               ],

--- a/meeting_summarizer/lib/features/summary/presentation/widgets/summary_type_selector.dart
+++ b/meeting_summarizer/lib/features/summary/presentation/widgets/summary_type_selector.dart
@@ -28,7 +28,7 @@ class SummaryTypeSelector extends StatelessWidget {
     return Card(
       elevation: 2,
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/meeting_summarizer/lib/features/summary/presentation/widgets/summary_viewer.dart
+++ b/meeting_summarizer/lib/features/summary/presentation/widgets/summary_viewer.dart
@@ -53,7 +53,7 @@ class _SummaryViewerState extends State<SummaryViewer> {
 
   Widget _buildHeader() {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: Theme.of(context).primaryColor.withValues(alpha: 0.1),
         borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
@@ -162,12 +162,12 @@ class _SummaryViewerState extends State<SummaryViewer> {
   List<Widget> _buildContent() {
     return [
       Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildSummaryContent(),
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
             if (widget.summary.keyPoints?.isNotEmpty ?? false)
               _buildKeyPoints(),
             if (widget.summary.sentiment != SentimentType.neutral)
@@ -213,7 +213,7 @@ class _SummaryViewerState extends State<SummaryViewer> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: 16),
+        const SizedBox(height: 12),
         Text(
           'Key Points',
           style: Theme.of(context).textTheme.titleSmall?.copyWith(
@@ -305,7 +305,7 @@ class _SummaryViewerState extends State<SummaryViewer> {
 
   Widget _buildMetadata() {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: Colors.grey[50],
         borderRadius: const BorderRadius.vertical(bottom: Radius.circular(4)),
@@ -320,14 +320,14 @@ class _SummaryViewerState extends State<SummaryViewer> {
                 Icons.verified,
                 Colors.green,
               ),
-              const SizedBox(width: 24),
+              const SizedBox(width: 16),
               _buildMetadataItem(
                 'Words',
                 widget.summary.wordCount.toString(),
                 Icons.text_fields,
                 Colors.blue,
               ),
-              const SizedBox(width: 24),
+              const SizedBox(width: 16),
               _buildMetadataItem(
                 'Length',
                 widget.summary.lengthCategory,
@@ -345,7 +345,7 @@ class _SummaryViewerState extends State<SummaryViewer> {
                 Icons.smart_toy,
                 Colors.purple,
               ),
-              const SizedBox(width: 24),
+              const SizedBox(width: 16),
               _buildMetadataItem(
                 'Reading Time',
                 '${widget.summary.estimatedReadingTime} min',

--- a/meeting_summarizer/lib/features/transcription/presentation/screens/transcription_screen.dart
+++ b/meeting_summarizer/lib/features/transcription/presentation/screens/transcription_screen.dart
@@ -367,23 +367,23 @@ class _TranscriptionScreenState extends State<TranscriptionScreen>
     if (screenWidth > 1200) {
       // Large desktop screens
       padding = const EdgeInsets.symmetric(horizontal: 80.0, vertical: 40.0);
-      verticalSpacing = 30.0;
-      majorSpacing = 40.0;
+      verticalSpacing = 24.0;
+      majorSpacing = 30.0;
     } else if (screenWidth > 800) {
       // Medium desktop/tablet screens
       padding = const EdgeInsets.symmetric(horizontal: 60.0, vertical: 32.0);
-      verticalSpacing = 25.0;
-      majorSpacing = 35.0;
+      verticalSpacing = 20.0;
+      majorSpacing = 26.0;
     } else if (screenWidth > 600) {
       // Small desktop/large tablet
       padding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
-      verticalSpacing = 20.0;
-      majorSpacing = 30.0;
+      verticalSpacing = 16.0;
+      majorSpacing = 22.0;
     } else {
       // Mobile screens
       padding = const EdgeInsets.all(24.0);
-      verticalSpacing = 16.0;
-      majorSpacing = 24.0;
+      verticalSpacing = 12.0;
+      majorSpacing = 18.0;
     }
 
     // Determine if we should use a wide layout
@@ -759,7 +759,7 @@ class _TranscriptionScreenState extends State<TranscriptionScreen>
             size: 80,
             color: theme.colorScheme.outline,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           Text(
             'No Transcription Yet',
             style: theme.textTheme.headlineSmall?.copyWith(

--- a/meeting_summarizer/lib/features/transcription/presentation/widgets/speaker_timeline.dart
+++ b/meeting_summarizer/lib/features/transcription/presentation/widgets/speaker_timeline.dart
@@ -58,7 +58,7 @@ class SpeakerTimeline extends StatelessWidget {
               size: 48,
               color: theme.colorScheme.outline,
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
             Text(
               'No Speaker Data Available',
               style: theme.textTheme.titleMedium?.copyWith(
@@ -88,7 +88,7 @@ class SpeakerTimeline extends StatelessWidget {
             fontWeight: FontWeight.bold,
           ),
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: 12),
 
         // Timeline
         Expanded(

--- a/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_controls.dart
+++ b/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_controls.dart
@@ -29,7 +29,7 @@ class TranscriptionControls extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(12),
@@ -43,7 +43,7 @@ class TranscriptionControls extends StatelessWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
 
           // Primary action button
           SizedBox(
@@ -87,7 +87,7 @@ class TranscriptionControls extends StatelessWidget {
             ],
           ),
 
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
 
           // Service status
           Row(

--- a/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_progress.dart
+++ b/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_progress.dart
@@ -21,7 +21,7 @@ class TranscriptionProgress extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(12),
@@ -56,7 +56,7 @@ class TranscriptionProgress extends StatelessWidget {
             ],
           ),
 
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
 
           // Progress bar
           LinearProgressIndicator(

--- a/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_settings.dart
+++ b/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_settings.dart
@@ -33,7 +33,7 @@ class TranscriptionSettings extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(12),
@@ -55,7 +55,7 @@ class TranscriptionSettings extends StatelessWidget {
             ],
           ),
 
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
 
           // Language selection
           Text(
@@ -84,7 +84,7 @@ class TranscriptionSettings extends StatelessWidget {
             }).toList(),
           ),
 
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
 
           // Feature toggles
           Text(

--- a/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_viewer.dart
+++ b/meeting_summarizer/lib/features/transcription/presentation/widgets/transcription_viewer.dart
@@ -235,7 +235,7 @@ class _TranscriptionViewerState extends State<TranscriptionViewer> {
           ),
         ],
 
-        const SizedBox(height: 16),
+        const SizedBox(height: 12),
 
         // Transcription content
         Expanded(child: _buildTranscriptionContent(theme)),
@@ -263,7 +263,7 @@ class _TranscriptionViewerState extends State<TranscriptionViewer> {
 
         return Container(
           margin: const EdgeInsets.only(bottom: 16),
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainerHighest.withValues(
               alpha: 0.3,
@@ -360,7 +360,7 @@ class _TranscriptionViewerState extends State<TranscriptionViewer> {
   /// Build plain text view
   Widget _buildPlainTextView(ThemeData theme) {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(12),


### PR DESCRIPTION
## Summary
- trim spacing in key widgets and screens
- use smaller padding defaults
- adjust layout spacing for a more compact UI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fadbde5708322a9138cdd0ee240e9